### PR TITLE
Add table range selection and CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,105 @@
+name: Build binaries
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  windows:
+    name: Windows executable
+    runs-on: windows-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Build executable
+        run: |
+          pyinstaller xlsxcutter.py --name xlsxcutter --onefile --windowed \
+            --add-data "knife.png;." --add-data "image.ico;."
+      - name: Package artifact
+        shell: pwsh
+        run: Compress-Archive -Path dist/xlsxcutter.exe -DestinationPath xlsxcutter-windows.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xlsxcutter-windows-x64
+          path: xlsxcutter-windows.zip
+
+  macos:
+    name: macOS app bundle
+    runs-on: macos-14
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Build app bundle
+        run: |
+          pyinstaller xlsxcutter.py --name xlsxcutter --windowed --onedir \
+            --add-data "knife.png:." --add-data "image.ico:."
+      - name: Package artifact
+        run: |
+          cd dist
+          zip -r ../xlsxcutter-macos-arm64.zip xlsxcutter.app
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xlsxcutter-macos-arm64
+          path: xlsxcutter-macos-arm64.zip
+
+  linux:
+    name: Ubuntu .deb package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Build binary
+        run: |
+          pyinstaller xlsxcutter.py --name xlsxcutter --onefile --windowed \
+            --add-data "knife.png:." --add-data "image.ico:."
+      - name: Create .deb package
+        run: |
+          VERSION="0.1.${GITHUB_RUN_NUMBER}"
+          mkdir -p build/deb/usr/local/bin
+          cp dist/xlsxcutter build/deb/usr/local/bin/xlsxcutter
+          chmod 755 build/deb/usr/local/bin/xlsxcutter
+          mkdir -p build/deb/DEBIAN
+          cat <<CONTROL > build/deb/DEBIAN/control
+          Package: xlsxcutter
+          Version: ${VERSION}
+          Section: utils
+          Priority: optional
+          Architecture: amd64
+          Maintainer: GitHub Actions <actions@github.com>
+          Description: XLSX Cutter desktop utility packaged from CI.
+          CONTROL
+          dpkg-deb --build --root-owner-group build/deb "xlsxcutter_${VERSION}_amd64.deb"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xlsxcutter-ubuntu-deb
+          path: xlsxcutter_*_amd64.deb

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ tables back into XLSX workbooks automatically.
 
 - Choose any sheet from an Excel workbook directly in the UI.
 - Split a sheet into multiple files while keeping the header row.
+- Define the table range by selecting the start cell and optional end cell before
+  splitting.
 - Export each chunk as XLSX, CSV, JSON and/or ODS (OpenDocument Spreadsheet).
 - Rebuild large CSV or JSON tables into a multi-sheet XLSX workbook when the
   data exceeds Excel's row limit.
@@ -19,18 +21,15 @@ tables back into XLSX workbooks automatically.
 ## Requirements
 
 - Python 3.10+
-- The Python packages listed in [`.env`](.env)
+- The Python packages listed in [`requirements.txt`](requirements.txt)
 
 Install the dependencies with:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
-set -a
-source .env
-set +a
 pip install --upgrade pip
-pip install $PYTHON_DEPENDENCIES
+pip install -r requirements.txt
 ```
 
 ## Running the app
@@ -44,7 +43,8 @@ python xlsxcutter.py
 1. Launch the app and open the **Split Excel** tab.
 2. Click **Browse** next to *Workbook* and select an `.xlsx` file. The sheet
    drop-down automatically populates.
-3. Choose the sheet to process and the number of rows per output file.
+3. Choose the sheet to process, the number of rows per output file, and the
+   top-left cell of the table. Provide an optional end cell to narrow the range.
 4. Select the output folder and tick one or more export formats.
 5. Press **Split** to generate the files. Each export reuses the sheet header
    and appends an incrementing suffix (`_part001`, `_part002`, ...).
@@ -74,22 +74,17 @@ The command above produces:
 - macOS: `dist/xlsxcutter` (Mach-O binary). Use `--onedir` instead of `--onefile`
   if you prefer a `.app` bundle: `pyinstaller xlsxcutter.py --name xlsxcutter --onedir --windowed`.
 
-## Automated releases
+## Continuous integration builds
 
-A GitHub Actions workflow (`.github/workflows/release.yml`) builds PyInstaller
-artifacts for Windows, macOS and Linux whenever you push a tag that starts with
-`v` (for example `v1.0.0`). The job uploads the executables to the matching
-GitHub release automatically.
+The GitHub Actions workflow at [`.github/workflows/build.yml`](.github/workflows/build.yml)
+creates runnable artifacts for each push and pull request:
 
-To cut a release:
+- Windows 11 (x64) standalone executable built with PyInstaller.
+- macOS (ARM64) application bundle built with PyInstaller.
+- Ubuntu (x64) `.deb` package containing the PyInstaller binary.
 
-```bash
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-Once the workflow completes, download the platform-specific binaries from the
-release page.
+Each job uploads its artifact so you can download and test the latest build
+directly from the workflow run.
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=1.5
+openpyxl>=3.1
+odfpy>=1.4


### PR DESCRIPTION
## Summary
- allow the split workflow to target a configurable cell range and reuse the header row from that range
- document the new behaviour and provide a requirements.txt for dependency installation
- add a GitHub Actions workflow that builds Windows, macOS, and Ubuntu artifacts on every push

## Testing
- python -m compileall xlsxcutter.py

------
https://chatgpt.com/codex/tasks/task_e_68dacd34028883288d7e24872e69e1ad